### PR TITLE
Directly generate TranslateManually type

### DIFF
--- a/output/symbol-name-sources.ts
+++ b/output/symbol-name-sources.ts
@@ -2559,10 +2559,20 @@ export const symbolData: {
     },
   },
 ];
-const translateManually = [
-  57495, 57654, 983359, 61239, 57665, 983382, 61244, 61245, 57671, 57426, 983376, 983269,
-] as const;
-export type TranslateManually = (typeof translateManually)[number];
+
+export type TranslateManually =
+  | 57495
+  | 57654
+  | 983359
+  | 61239
+  | 57665
+  | 983382
+  | 61244
+  | 61245
+  | 57671
+  | 57426
+  | 983376
+  | 983269;
 
 /*
  * Could not find a source for (did the definitions disappear?): 

--- a/src/generate-symbols.ts
+++ b/src/generate-symbols.ts
@@ -507,10 +507,10 @@ if (hasDupes) {
 const outString =
   "export const symbolData: {codepoint: number; glyph: string, source?: {tableName: 'Trait' | 'InventoryItem' | 'SandboxPerk' | 'ActivityMode' | 'Objective'| 'ItemCategory' | 'InventoryBucket' | 'Faction' | 'Stat' | 'DamageType', hash: number, fromRichText: boolean }}[] =" +
   JSON.stringify(output, null, 2) +
-  ';\nconst translateManually = ' +
-  JSON.stringify(translateManually, null, 2) +
-  'as const;\n' +
-  'export type TranslateManually = typeof translateManually[number];\n\n' +
+  ';\n\n' +
+  'export type TranslateManually = ' +
+  translateManually.join(' | ') +
+  ';\n\n' +
   '/*\n * Could not find a source for (did the definitions disappear?): \n' +
   failedToFindSource.map((name) => ` * ${name}`).join('\n') +
   '\n\n' +


### PR DESCRIPTION
The way it was before, typescript-eslint could complain that the value was only ever used for its type, which is true.