### PR TITLE
Prefer sandbox perks to objectives - they change less

### DIFF
--- a/output/symbol-name-sources.ts
+++ b/output/symbol-name-sources.ts
@@ -597,8 +597,8 @@ export const symbolData: {
     codepoint: 57617,
     glyph: '',
     source: {
-      tableName: 'Objective',
-      hash: 45245118,
+      tableName: 'SandboxPerk',
+      hash: 528482921,
       fromRichText: true,
     },
   },
@@ -2035,8 +2035,8 @@ export const symbolData: {
     codepoint: 57667,
     glyph: '',
     source: {
-      tableName: 'Objective',
-      hash: 85239849,
+      tableName: 'SandboxPerk',
+      hash: 1637834409,
       fromRichText: true,
     },
   },
@@ -2044,8 +2044,8 @@ export const symbolData: {
     codepoint: 57668,
     glyph: '',
     source: {
-      tableName: 'Objective',
-      hash: 33657378,
+      tableName: 'SandboxPerk',
+      hash: 1554078996,
       fromRichText: true,
     },
   },
@@ -2053,8 +2053,8 @@ export const symbolData: {
     codepoint: 57664,
     glyph: '',
     source: {
-      tableName: 'Objective',
-      hash: 85535853,
+      tableName: 'SandboxPerk',
+      hash: 1821367741,
       fromRichText: true,
     },
   },
@@ -2062,8 +2062,8 @@ export const symbolData: {
     codepoint: 57657,
     glyph: '',
     source: {
-      tableName: 'Objective',
-      hash: 270151386,
+      tableName: 'SandboxPerk',
+      hash: 35992462,
       fromRichText: true,
     },
   },
@@ -2579,11 +2579,6 @@ export type TranslateManually =
 
 
  * Unused rich text replacements (these should only be input actions replaced with the mapped buttons by the game): 
- * [Stasis: Glyph 0]
- * [Stasis: Glyph 3 Locked]
- * [Stasis: Glyph 1 Locked]
- * [Stasis: Glyph 2 Locked]
- * [Insert Medal Here]
  * [Aim Down Sights]
  * [Alternate Weapon Action]
  * [Light Attack]
@@ -2597,4 +2592,9 @@ export type TranslateManually =
  * [Boost]
  * [Air Move]
  * [Brake]
+ * [Stasis: Glyph 0]
+ * [Stasis: Glyph 3 Locked]
+ * [Stasis: Glyph 1 Locked]
+ * [Stasis: Glyph 2 Locked]
+ * [Insert Medal Here]
  */

--- a/src/generate-symbols.ts
+++ b/src/generate-symbols.ts
@@ -418,17 +418,17 @@ type fromRichTextManifestSourceData = Record<
 const fromRichTexts: fromRichTextManifestSourceData = {};
 const iconFinder = /(\[[^\]]+\])/g;
 
-objectives.forEach((objective) => {
-  const match = objective.progressDescription?.match(iconFinder);
-  if (match?.length === 1 && !fromRichTexts[match[0]]) {
-    fromRichTexts[match[0]] = ['Objective', objective.hash, false];
-  }
-});
-
 perks.forEach((perk) => {
   const match = perk.displayProperties.description?.match(iconFinder);
   if (match?.length === 1 && !fromRichTexts[match[0]]) {
     fromRichTexts[match[0]] = ['SandboxPerk', perk.hash, false];
+  }
+});
+
+objectives.forEach((objective) => {
+  const match = objective.progressDescription?.match(iconFinder);
+  if (match?.length === 1 && !fromRichTexts[match[0]]) {
+    fromRichTexts[match[0]] = ['Objective', objective.hash, false];
   }
 });
 


### PR DESCRIPTION
This tries to find a perk that has the symbol before looking for objectives, since objectives tend to get removed from the manifest whereas I don't think perks will.